### PR TITLE
File not found error in `del_cached()` rectified

### DIFF
--- a/pandas_cache/pandas_cache.py
+++ b/pandas_cache/pandas_cache.py
@@ -73,6 +73,7 @@ def test():
 def del_cached():
     # TODO: update this to use the glob format from pd_cache to safeguard deleting arbitrary files.
     cached = os.listdir('./.pd_cache/')
+    cached = ['./.pd_cache/'+ file_name for file_name in cached]
     print(cached)
     if len(cached) > 0:
         [os.remove(x) for x in cached]


### PR DESCRIPTION
There was an error in the way the files were named. `os.remove(x)` needs the name of the directory too, in addition to the filename.